### PR TITLE
fix(api): OpenAPI 生成を zod v4 + zod-to-openapi v8 推奨パターンに移行

### DIFF
--- a/api/generate-openapi.ts
+++ b/api/generate-openapi.ts
@@ -3,11 +3,12 @@ import {
   OpenApiGeneratorV31,
 } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
-import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { writeFileSync, mkdirSync } from "fs";
-import { resolve } from "path";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 
-extendZodWithOpenApi(z);
+// ESM では __dirname が未定義。import.meta.url から導出する。
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 import {
   ChapterProgressSchema,
@@ -24,15 +25,10 @@ import { NarrationResponseSchema } from "./schemas/narration";
 
 const registry = new OpenAPIRegistry();
 
-// Register schemas
-registry.register("ChapterProgress", ChapterProgressSchema);
-registry.register("ProgressListResponse", ProgressListResponseSchema);
-registry.register("UpdateProgressRequest", UpdateProgressRequestSchema);
-registry.register("QuizResponse", QuizResponseSchema);
-registry.register("QuizSubmitRequest", QuizSubmitRequestSchema);
-registry.register("QuizEvaluation", QuizEvaluationSchema);
-registry.register("TutorAskRequest", TutorAskRequestSchema);
-registry.register("NarrationResponse", NarrationResponseSchema);
+// Schema 名は各 schemas/*.ts で `.meta({ id: "..." })` として宣言済 (zod v4 + zod-to-openapi v8 の
+// 公式推奨パターン)。registry.register("Name", schema) は不要 — registry が .meta.id を見て
+// components/schemas に自動登録する。
+// extendZodWithOpenApi も呼ばない (.meta は zod v4 ネイティブメソッドのため拡張不要)。
 
 // Auth
 registry.registerPath({

--- a/api/schemas/narration.ts
+++ b/api/schemas/narration.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 
-export const NarrationResponseSchema = z.object({
-  chapterId: z.string(),
-  audioUrl: z.string().optional(),
-  audioBase64: z.string().optional(),
-  contentType: z.literal("audio/mpeg"),
-  text: z.string(),
-});
+export const NarrationResponseSchema = z
+  .object({
+    chapterId: z.string(),
+    audioUrl: z.string().optional(),
+    audioBase64: z.string().optional(),
+    contentType: z.literal("audio/mpeg"),
+    text: z.string(),
+  })
+  .meta({ id: "NarrationResponse" });
 
 export type NarrationResponse = z.infer<typeof NarrationResponseSchema>;

--- a/api/schemas/progress.ts
+++ b/api/schemas/progress.ts
@@ -1,21 +1,27 @@
 import { z } from "zod";
 
-export const ChapterProgressSchema = z.object({
-  chapterId: z.string(),
-  status: z.enum(["not_started", "in_progress", "completed"]),
-  completedAt: z.string().optional(),
-  score: z.number().min(0).max(100).optional(),
-  updatedAt: z.string(),
-});
+export const ChapterProgressSchema = z
+  .object({
+    chapterId: z.string(),
+    status: z.enum(["not_started", "in_progress", "completed"]),
+    completedAt: z.string().optional(),
+    score: z.number().min(0).max(100).optional(),
+    updatedAt: z.string(),
+  })
+  .meta({ id: "ChapterProgress" });
 
-export const ProgressListResponseSchema = z.object({
-  progress: z.array(ChapterProgressSchema),
-});
+export const ProgressListResponseSchema = z
+  .object({
+    progress: z.array(ChapterProgressSchema),
+  })
+  .meta({ id: "ProgressListResponse" });
 
-export const UpdateProgressRequestSchema = z.object({
-  status: z.enum(["not_started", "in_progress", "completed"]),
-  score: z.number().min(0).max(100).optional(),
-});
+export const UpdateProgressRequestSchema = z
+  .object({
+    status: z.enum(["not_started", "in_progress", "completed"]),
+    score: z.number().min(0).max(100).optional(),
+  })
+  .meta({ id: "UpdateProgressRequest" });
 
 export const UpdateProgressResponseSchema = ChapterProgressSchema;
 

--- a/api/schemas/quiz.ts
+++ b/api/schemas/quiz.ts
@@ -8,30 +8,36 @@ export const QuizQuestionSchema = z.object({
   explanation: z.string(),
 });
 
-export const QuizResponseSchema = z.object({
-  questions: z.array(QuizQuestionSchema),
-});
+export const QuizResponseSchema = z
+  .object({
+    questions: z.array(QuizQuestionSchema),
+  })
+  .meta({ id: "QuizResponse" });
 
-export const QuizSubmitRequestSchema = z.object({
-  answers: z.array(
-    z.object({
-      questionId: z.string(),
-      selectedIndex: z.number(),
-    }),
-  ),
-});
+export const QuizSubmitRequestSchema = z
+  .object({
+    answers: z.array(
+      z.object({
+        questionId: z.string(),
+        selectedIndex: z.number(),
+      }),
+    ),
+  })
+  .meta({ id: "QuizSubmitRequest" });
 
-export const QuizEvaluationSchema = z.object({
-  score: z.number().min(0).max(100),
-  feedback: z.string(),
-  corrections: z.array(
-    z.object({
-      questionId: z.string(),
-      correct: z.boolean(),
-      explanation: z.string().optional(),
-    }),
-  ),
-});
+export const QuizEvaluationSchema = z
+  .object({
+    score: z.number().min(0).max(100),
+    feedback: z.string(),
+    corrections: z.array(
+      z.object({
+        questionId: z.string(),
+        correct: z.boolean(),
+        explanation: z.string().optional(),
+      }),
+    ),
+  })
+  .meta({ id: "QuizEvaluation" });
 
 export type QuizQuestion = z.infer<typeof QuizQuestionSchema>;
 export type QuizSubmitRequest = z.infer<typeof QuizSubmitRequestSchema>;

--- a/api/schemas/tutor.ts
+++ b/api/schemas/tutor.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
 
-export const TutorAskRequestSchema = z.object({
-  question: z.string().min(1).max(1000),
-  chapterId: z.string().optional(),
-  context: z.string().optional(),
-});
+export const TutorAskRequestSchema = z
+  .object({
+    question: z.string().min(1).max(1000),
+    chapterId: z.string().optional(),
+    context: z.string().optional(),
+  })
+  .meta({ id: "TutorAskRequest" });
 
 export type TutorAskRequest = z.infer<typeof TutorAskRequestSchema>;


### PR DESCRIPTION
## 問題
\`Deploy API Docs\` workflow が 2026-04-02 から push 全失敗、Pages が 404。
原因: \`extendZodWithOpenApi(z)\` の呼び出しが import hoisting で schemas 評価より遅く、registry.register が \`.openapi()\` を呼ぶ時点で拡張されていない。

## 対処
公式 README の v8 + zod v4 推奨パターン (\`.meta()\` ベース) に移行:
- 各 schema に \`.meta({ id: 'Name' })\` を付与
- \`registry.register('Name', schema)\` を削除
- \`extendZodWithOpenApi\` 関連削除
- ESM の \`__dirname\` 未定義も修正

\`registerPath\` は維持 (\`.openapi()\` に依存しない)。

## 検証
- ローカル \`pnpm run generate-openapi\` 成功 (CI と同じスクリプト)
- 生成 \`openapi.json\` で \`components/schemas\` 7 個、\`paths\` 8 個、\`\$ref\` 解決確認

Closes #18